### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# PowerModelsMCDC.jl changelog
+
+All notable changes to PowerModelsMCDC.jl will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- This changelog
+
+## [0.1.0] - 2023-07-15
+
+Initial release.
+Includes OPF probem for HVDC networks, with multiconductor model of the DC grid.
+
+[unreleased]: https://github.com/Electa-Git/PowerModelsMCDC.jl/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Electa-Git/PowerModelsMCDC.jl/releases/tag/v0.1.0


### PR DESCRIPTION
Closes #4.

Links related to v0.1.0 won't work until the v0.1.0 release is created on GitHub, but this PR can be merged nevertheless.