### PR TITLE
Fix DCP model

### DIFF
--- a/src/formdcgrid/dcp.jl
+++ b/src/formdcgrid/dcp.jl
@@ -31,9 +31,14 @@ function constraint_ohms_dc_branch(pm::_PM.AbstractDCPModel, n::Int, f_bus, t_bu
     for k = 1:3
         for (line, d) in bus_arcs_dcgrid_cond[(f_bus, k)]
             if line == f_idx
-                g = 1 / r[d]
-                JuMP.@constraint(pm.model, i_dc_fr[d] == g * (vmdc_fr[k] - vmdc_to[k]))
-                JuMP.@constraint(pm.model, i_dc_to[d] == g * (vmdc_to[k] - vmdc_fr[k]))
+                if r[d] == 0
+                    JuMP.@constraint(pm.model, i_dc_fr[d] + i_dc_to[d] == 0)
+                    JuMP.@constraint(pm.model, vmdc_fr[k] - vmdc_to[k] == 0)
+                else
+                    g = 1 / r[d]
+                    JuMP.@constraint(pm.model, i_dc_fr[d] == g * (vmdc_fr[k] - vmdc_to[k]))
+                    JuMP.@constraint(pm.model, i_dc_to[d] == g * (vmdc_to[k] - vmdc_fr[k]))
+                end
             end
         end
     end

--- a/src/formdcgrid/dcp.jl
+++ b/src/formdcgrid/dcp.jl
@@ -31,14 +31,9 @@ function constraint_ohms_dc_branch(pm::_PM.AbstractDCPModel, n::Int, f_bus, t_bu
     for k = 1:3
         for (line, d) in bus_arcs_dcgrid_cond[(f_bus, k)]
             if line == f_idx
-                if r[d] == 0
-                    JuMP.@constraint(pm.model, i_dc_fr[d] + i_dc_to[d] == 0)
-                    JuMP.@constraint(pm.model, vmdc_fr[k] - vmdc_to[k] == 0)
-                else
-                    g = 1 / r[d]
-                    JuMP.@constraint(pm.model, i_dc_fr[d] == g * (vmdc_fr[k] - vmdc_to[k]))
-                    JuMP.@constraint(pm.model, i_dc_to[d] == g * (vmdc_to[k] - vmdc_fr[k]))
-                end
+                g = 1 / r[d]
+                JuMP.@constraint(pm.model, i_dc_fr[d] == g * (vmdc_fr[k] - vmdc_to[k]))
+                JuMP.@constraint(pm.model, i_dc_to[d] == g * (vmdc_to[k] - vmdc_fr[k]))
             end
         end
     end

--- a/src/formdcgrid/dcp.jl
+++ b/src/formdcgrid/dcp.jl
@@ -31,8 +31,14 @@ function constraint_ohms_dc_branch(pm::_PM.AbstractDCPModel, n::Int, f_bus, t_bu
     for k = 1:3
         for (line, d) in bus_arcs_dcgrid_cond[(f_bus, k)]
             if line == f_idx
-                JuMP.@constraint(pm.model, i_dc_fr[d] + i_dc_to[d] == 0)
-                JuMP.@constraint(pm.model, vmdc_fr[k] - vmdc_to[k] == 0)
+                if r[d] == 0
+                    JuMP.@constraint(pm.model, i_dc_fr[d] + i_dc_to[d] == 0)
+                    JuMP.@constraint(pm.model, vmdc_fr[k] - vmdc_to[k] == 0)
+                else
+                    g = 1 / r[d]
+                    JuMP.@constraint(pm.model, i_dc_fr[d] == g * (vmdc_fr[k] - vmdc_to[k]))
+                    JuMP.@constraint(pm.model, i_dc_to[d] == g * (vmdc_to[k] - vmdc_fr[k]))
+                end
             end
         end
     end


### PR DESCRIPTION
This PR fixes the DCP model for the DC grid, which was only partially implemented based on the I-V formulation.

In particular, constraints have been added for:
- dependence of DC branch current on DC bus voltage in case of nonzero branch resistance.
- converter ground shunt DC current
- linearized term for converter ground active power.