### PR TITLE
Emplace package documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,24 +1,25 @@
 name: Documentation
+
 on:
   push:
-    branches: [master]
+    branches:
+      - master
     tags: '*'
   pull_request:
-    types: [opened, synchronize, reopened]
+
 jobs:
-  docs:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: Documentation
+  build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - name: Install Dependencies
-        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and Deploy
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs docs/make.jl
+        run: julia --project=docs/ docs/make.jl

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,5 +28,5 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
           # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/Electa-Git/PowerModelsMCDC.jl/workflows/CI/badge.svg)](https://github.com/Electa-Git/PowerModelsMCDC.jl/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/Electa-Git/PowerModelsMCDC.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/Electa-Git/PowerModelsMCDC.jl)
+[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://electa-git.github.io/PowerModelsMCDC.jl/dev/)
 
 PowerModelsMCDC.jl is a Julia/JuMP/PowerModels package for hybrid AC/DC systems with multiconductor model of the DC grid in order to represent unbalanced HVDC grids. The positive and negative poles of bipolar converter stations are modeled separately, and DC buses are modeled using three terminals: the positive, the negative, and the neutral terminal. Each conductor of a DC branch is modeled separately, including the metallic return conductor and converter grounding.
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+site/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Documentation for PowerModelsMCDC.jl
+
+You can read this documentation online at
+<https://electa-git.github.io/PowerModelsMCDC.jl/dev/>.
+
+## Preview the documentation (for developers)
+
+While developing PowerModelsMCDC.jl you can preview the documentation locally in your
+browser with live-reload capability, i.e., when modifying a file, every browser (tab)
+currently displaying the corresponding page is automatically refreshed.
+
+### Instructions for *nix
+
+1. Copy the following zsh/Julia code snippet:
+
+   ```julia
+   #!/bin/zsh
+   #= # The following line is zsh code
+   julia -i $0:a # The string `$0:a` represents this file in zsh
+   =# # Following lines are Julia code
+   import Pkg
+   Pkg.activate(; temp=true)
+   Pkg.develop("PowerModelsMCDC")
+   Pkg.add("Documenter")
+   Pkg.add("LiveServer")
+   using PowerModelsMCDC, LiveServer
+   cd(dirname(dirname(pathof(PowerModelsMCDC))))
+   servedocs()
+   exit()
+   ```
+
+2. Save it as a zsh script (name it like `preview_powermodelsmcdc_docs.sh`).
+3. Assign execute permission to the script: `chmod u+x preview_powermodelsmcdc_docs.sh`.
+4. Run the script.
+5. Open your favorite web browser and navigate to `http://localhost:8000`.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,15 +1,21 @@
 using Documenter, PowerModelsMCDC
 
 makedocs(
-    modules     = [PowerModelsMCDC],
-    format      = Documenter.HTML(mathengine = Documenter.MathJax()),
-    sitename    = "PowerModelsMCDC.jl",
-    authors     = "Chandra Kant Jat, Hakan Ergun, Jay Dave",
-    pages       = [
-              "Home"    => "index.md",
-                 ]
+    modules = [PowerModelsMCDC],
+    sitename = "PowerModelsMCDC",
+    pages = [
+        "Home" => "index.md"
+        "Manual" => [
+            "Network data format" => "man/network-data.md"
+            "Network formulations" => "man/formulations.md"
+            "Problem specifications" => "man/specifications.md"
+        ]
+        "API" => [
+            "Functions" => "api/functions.md"
+        ]
+    ]
 )
 
 deploydocs(
-     repo = "github.com/Electa-Git/PowerModelsMCDC.jl.git"
+    repo = "github.com/Electa-Git/PowerModelsMCDC.jl.git"
 )

--- a/docs/src/api/functions.md
+++ b/docs/src/api/functions.md
@@ -1,0 +1,26 @@
+# Functions
+
+```@meta
+CurrentModule = PowerModelsMCDC
+```
+
+
+## Index
+
+```@index
+```
+
+
+## Working with input data
+
+```@docs
+parse_file
+```
+
+
+## Problem specifications
+
+```@docs
+solve_mcdcopf
+build_mcdcopf
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,2 +1,56 @@
-# PowerModelsMCDC.jl Documentation
+# PowerModelsMCDC.jl documentation
+
+
+## Overview
+
+[PowerModelsMCDC.jl](https://github.com/Electa-Git/PowerModelsMCDC.jl) is a Julia package
+for the steady-state optimization of hybrid AC/DC power networks, with a focus on
+multiconductor modeling of DC networks.
+
+This package builds upon [PowerModels.jl](https://github.com/lanl-ansi/PowerModels.jl),
+which is used for modeling the AC system, and is similar to
+[PowerModelsACDC.jl](https://github.com/Electa-Git/PowerModelsACDC.jl), which features a
+single-conductor model of DC networks.
+
+PowerModelsMCDC.jl is particularly suitable for representing unbalanced HVDC networks:
+
+- DC buses are modeled using 3 terminals: positive, negative, and neutral.
+- Each conductor of a DC branch is individually modeled, including the metallic return
+  conductor.
+- Both monopolar and bipolar converter stations are considered; in the latter case, the two
+  poles are modeled separately.
+
+
+## Installation
+
+From Julia, PowerModelsMCDC can be installed using the built-in package manager:
+
+```julia
+using Pkg
+Pkg.add("PowerModelsMCDC")
+```
+
+
+## Citing PowerModelsMCDC.jl
+
+If you find PowerModelsMCDC.jl useful in your work, we kindly request that you cite the
+following [preprint](https://arxiv.org/abs/2211.06283):
+
+```bibtex
+@misc{PowerModelsMCDC,
+    doi = {10.48550/ARXIV.2211.06283},
+    url = {https://arxiv.org/abs/2211.06283},
+    author = {Jat, Chandra Kant and Dave, Jay and Van Hertem, Dirk and Ergun, Hakan},
+    title = {Unbalanced OPF Modelling for Mixed Monopolar and Bipolar HVDC Grid Configurations},
+    publisher = {arXiv},
+    year = {2022},
+    copyright = {Creative Commons Attribution 4.0 International}
+}
+```
+
+
+## License
+
+This code is provided under a
+[BSD 3-Clause License](https://github.com/Electa-Git/PowerModelsMCDC.jl/blob/master/LICENSE.md).
 

--- a/docs/src/man/formulations.md
+++ b/docs/src/man/formulations.md
@@ -1,0 +1,40 @@
+# Network formulations
+
+The optimization problems defined in PowerModelsMCDC support two network formulations:
+
+- `PowerModels.ACPPowerModel`;
+- `PowerModels.DCPPowerModel`.
+
+For an overview of the type hierarchy and details on how each formulation is defined over AC
+networks, refer to
+[PowerModels' “Network Formulations” documentation](https://lanl-ansi.github.io/PowerModels.jl/stable/formulations/).
+
+These formulations are extended in PowerModelsMCDC to include a multi-conductor model for DC
+networks, as detailed below.
+
+
+## `ACPPowerModel`
+
+Class: NLP.
+
+Variables: bus terminal voltage, branch conductor current.
+
+Current flows in meshed DC networks follow Ohm's law, i.e., considering the resistance of
+the DC branch conductors, and the DC branch conductors are lossy, according to Ohm's law.
+
+Converters have parametric losses.
+
+
+## `DCPPowerModel`
+
+Class: LP.
+
+Variables: bus terminal voltage, branch conductor current.
+
+Current flows in a meshed DC network follow Ohm's law, i.e., considering the resistance of
+branch conductors, but the DC branch conductors are lossless.
+
+All DC voltages are defined up to a constant term. Therefore, the only meaningful use of the
+voltage values provided in results is to compute voltage drops over DC branch conductors.
+
+Converters have parametric losses (constant and linear terms only).

--- a/docs/src/man/network-data.md
+++ b/docs/src/man/network-data.md
@@ -1,0 +1,48 @@
+# Network data format
+
+```@meta
+CurrentModule = PowerModelsMCDC
+
+# In this documentation, we use LaTeX newlines (i.e., ``\\``) to achieve line breaks in
+# table cells.
+# It is a clumsy trick, and what is worse, it inserts tons of boilerplate code in the HTML,
+# instead of just a <br /> tag. As an alternative, tables could be directly coded in HTML.
+```
+
+
+## The network data dictionary
+
+Since PowerModelsMCDC extends the
+[PowerModelsACDC data format](https://electa-git.github.io/PowerModelsACDC.jl/dev/parser/),
+most of the parameters have the same meaning as in PowerModelsACDC.
+The remaining parameters are described below.
+
+
+### Converter (`convdc`)
+
+| Field         | Values  | Data U.M. | Description                                        |
+| :------------ | :-----: | :-------: | :------------------------------------------------- |
+| `conv_confi`  | {1,2}   |           | Configuration:``\\``1: monopolar (symmetric or asymmetric)``\\``2: bipolar |
+| `connect_at`  | {0,1,2} |           | Bus terminals where the converter is connected (only used if the converter is monopolar):``\\``0: positive and negative``\\``1: positive and neutral``\\``2: negative and neutral |
+| `ground_type` | {0,1}   |           | Neutral terminal grounding type:``\\``0: ungrounded neutral terminal``\\``1: grounded neutral terminal |
+| `ground_z`    | [0,+∞)  | p.u.      | Grounding impedance (only used if `ground_type == 1`) |
+
+
+### DC branch (`branchdc`)
+
+| Field         | Values  | Data U.M. | Description                                        |
+| :------------ | :-----: | :-------: | :------------------------------------------------- |
+| `line_confi`  | {1,2}   |           | Configuration:``\\``1: monopolar (symmetric or asymmetric)``\\``2: bipolar |
+| `connect_at`  | {0,1,2} |           | Bus terminals where the branch is connected (only used if the DC branch is monopolar):``\\``0: positive and negative``\\``1: positive and neutral``\\``2: negative and neutral |
+| `return_type` |         |           | **Not used in package code, but present in input files.**``\\``Originally meant for modeling ground return (1) instead of metallic return (2). |
+| `return_z`    | (0,+∞)  | p.u.      | Metallic return impedance                          |
+
+
+## Working with Matpower files
+
+Input data can be provided in the form of a file structured similarly to the format defined
+by Matpower.
+An
+[example `.m` file](https://github.com/Electa-Git/PowerModelsMCDC.jl/blob/master/test/data/matacdc_scripts/case5_2grids_MC.m)
+is available to illustrate the syntax.
+You can provide such a file to PowerModelsMCDC by using the [`parse_file`](@ref) function.

--- a/docs/src/man/specifications.md
+++ b/docs/src/man/specifications.md
@@ -1,0 +1,13 @@
+# Problem specifications
+
+Currently, PowerModelsMCDC only supports the OPF problem.
+
+
+## OPF
+
+The Optimal Power Flow (OPF) problem over a hybrid AC/DC network.
+
+It uses a single-phase representation for the AC part, and a multi-conductor model for the
+DC part.
+
+To build and solve such a problem, use the [`solve_mcdcopf`](@ref) function.

--- a/src/io/parse.jl
+++ b/src/io/parse.jl
@@ -1,8 +1,9 @@
 """
     parse_file(file; <keyword arguments>)
 
-Parse a Matpower .m `file` or PTI (PSS(R)E-v33) .raw `file` into a PowerModelsMCDC data
-structure. Keyword arguments, if any, are forwarded to `PowerModels.parse_file`.
+Parse a Matpower .m `file` into a PowerModelsMCDC data structure.
+
+Keyword arguments, if any, are forwarded to `PowerModels.parse_file`.
 """
 function parse_file(file::String; kwargs...)
     data = _PM.parse_file(file; kwargs...)

--- a/src/prob/mcdcopf.jl
+++ b/src/prob/mcdcopf.jl
@@ -1,17 +1,33 @@
 export solve_mcdcopf
 
-""
-function solve_mcdcopf(file::String, model_type::Type, solver; kwargs...)
+"""
+    solve_mcdcopf(file, model_type, optimizer; <keyword arguments>)
+    solve_mcdcopf(data, model_type, optimizer; <keyword arguments>)
+
+Build and solve the OPF problem over a hybrid AC/DC network, using a multi-conductor model for the DC part.
+
+Input can be a Matpower `file` or a `data` dictionary.
+The OPF problem being built is the one defined in `build_mcdcopf`.
+Keyword arguments, if any, are forwarded to `PowerModels.solve_model`.
+"""
+function solve_mcdcopf end
+
+function solve_mcdcopf(file::String, model_type::Type, optimizer; kwargs...)
     data = parse_file(file)
-    return solve_mcdcopf(data, model_type, solver; ref_extensions=[add_ref_dcgrid!], kwargs...)
+    return solve_mcdcopf(data, model_type, optimizer; ref_extensions=[add_ref_dcgrid!], kwargs...)
 end
 
-""
-function solve_mcdcopf(data::Dict{String,Any}, model_type::Type, solver; kwargs...)
-    return _PM.solve_model(data, model_type, solver, build_mcdcopf; ref_extensions=[add_ref_dcgrid!], kwargs...)
+function solve_mcdcopf(data::Dict{String,Any}, model_type::Type, optimizer; kwargs...)
+    return _PM.solve_model(data, model_type, optimizer, build_mcdcopf; ref_extensions=[add_ref_dcgrid!], kwargs...)
 end
 
-""
+"""
+    build_mcdcopf(pm::PowerModels.AbstractPowerModel)
+
+Build the OPF problem over a hybrid AC/DC network, using a multi-conductor model for the DC part.
+
+The objective is the minimization of generation cost.
+"""
 function build_mcdcopf(pm::_PM.AbstractPowerModel)
     _PM.variable_bus_voltage(pm, bounded=true)
     _PM.variable_gen_power(pm, bounded=true)

--- a/test/data/matacdc_scripts/case5_2grids_MC.m
+++ b/test/data/matacdc_scripts/case5_2grids_MC.m
@@ -1,8 +1,5 @@
-function mpc = case5_2gr_PM.ids()
-%case 5 nodes    Power flow data for 5 bus, 2 generator case.
-%   Please see 'help caseformat' for details on the case file format.
-%
-%   case file can be used together with dc case files "case5_stagg_....m"
+function mpc = case5_2grids_MC()
+%CASE5_2GRIDS_MC
 %
 %   Network data from ...
 %   G.W. Stagg, A.H. El-Abiad, "Computer methods in power system analysis",
@@ -10,103 +7,108 @@ function mpc = case5_2gr_PM.ids()
 %
 %   MATPOWER case file data provided by Jef Beerten.
 
-%% MATPOWER Case Format : Version 1
+%% MATPOWER Case Format : Version 2
+mpc.version = '2';
+
 %%-----  Power Flow Data  -----%%
 %% system MVA base
 mpc.baseMVA = 100;
 
-%% bus data
-%	bus_i	type	Pd	Qd	Gs	Bs	area	Vm      Va	baseKV	zone	Vmax	Vmin
+%% AC bus
+% bus_i type Pd Qd Gs Bs area   Vm Va baseKV zone Vmax Vmin
 mpc.bus = [
-	1       3       0	0	0   0   1       1.06	0	345     1       1.1     0.9;
-	2       1       20	10	0   0   1       1       0	345     1       1.1     0.9;
-	3       1       45	15	0   0   1       1       0	345     1       1.1     0.9;
-	4       1       40	5	0   0   1       1       0	345     1       1.1     0.9;
-	5       1       60	10	0   0   1       1       0	345     1       1.1     0.9;
-  6       3       0	0	0   0   2       1.06	0	345     1       1.1     0.9;
-	7       1       20	10	0   0   2       1       0	345     1       1.1     0.9;
-	8       1       45	15	0   0   2       1       0	345     1       1.1     0.9;
-	9       1       40	5	0   0   2       1       0	345     1       1.1     0.9;
-	10      1       60	10	0   0   2       1       0	345     1       1.1     0.9;
-	11      3       50	10	0   0   3       1       0	345     1       1.1     0.9;
-
+      1    3  0  0  0  0    1 1.06  0    345    1  1.1  0.9;
+      2    1 20 10  0  0    1 1     0    345    1  1.1  0.9;
+      3    1 45 15  0  0    1 1     0    345    1  1.1  0.9;
+      4    1 40  5  0  0    1 1     0    345    1  1.1  0.9;
+      5    1 60 10  0  0    1 1     0    345    1  1.1  0.9;
+      6    3  0  0  0  0    2 1.06  0    345    1  1.1  0.9;
+      7    1 20 10  0  0    2 1     0    345    1  1.1  0.9;
+      8    1 45 15  0  0    2 1     0    345    1  1.1  0.9;
+      9    1 40  5  0  0    2 1     0    345    1  1.1  0.9;
+     10    1 60 10  0  0    2 1     0    345    1  1.1  0.9;
+     11    3 50 10  0  0    3 1     0    345    1  1.1  0.9;
 ];
 
-%% generator data
-%	bus	Pg      Qg	Qmax	Qmin	Vg	mBase       status	Pmax	Pmin	pc1 pc2 qlcmin qlcmax qc2min qc2max ramp_agc ramp_10 ramp_30 ramp_q apf
+%% generator
+% bus Pg Qg Qmax Qmin   Vg mBase status Pmax Pmin
 mpc.gen = [
-	1	0       0	500      -500    1.06	100       1       250     10 0 0 0 0 0 0 0 0 0 0 0;
-  2	40      0	300      -300    1      100       1       300     10 0 0 0 0 0 0 0 0 0 0 0;
-  6	0       0	500      -500    1.06	100       1       250     10 0 0 0 0 0 0 0 0 0 0 0;
-  7	40      0	300      -300    1      100       1       300     10 0 0 0 0 0 0 0 0 0 0 0;
-  11	40      0	300      -300    1      100       1       300     10 0 0 0 0 0 0 0 0 0 0 0;
-
+    1  0  0  500 -500 1.06   100      1  250   10;
+    2 40  0  300 -300 1      100      1  300   10;
+    6  0  0  500 -500 1.06   100      1  250   10;
+    7 40  0  300 -300 1      100      1  300   10;
+   11 40  0  300 -300 1      100      1  300   10;
 ];
 
-%% branch data
-%	fbus	tbus	r	x	b	rateA	rateB	rateC	ratio	angle
-%	status angmin angmax
-mpc.branch = [
-    1   2   0.02    0.06    0.06    100   100   100     0       0       1 -60 60;
-    1   3   0.08    0.24    0.05    100   100   100     0       0       1 -60 60;
-    2   3   0.06    0.18    0.04    100   100   100     0       0       1 -60 60;
-    2   4   0.06    0.18    0.04    100   100   100     0       0       1 -60 60;
-    2   5   0.04    0.12    0.03    100   100   100     0       0       1 -60 60;
-    3   4   0.01    0.03    0.02    100   100   100     0       0       1 -60 60;
-    4   5   0.08    0.24    0.05    100   100   100     0       0       1 -60 60;
-    6   7   0.02    0.06    0.06    100   100   100     0       0       1 -60 60;
-    6   8   0.08    0.24    0.05    100   100   100     0       0       1 -60 60;
-    7   8   0.06    0.18    0.04    100   100   100     0       0       1 -60 60;
-    7   9   0.06    0.18    0.04    100   100   100     0       0       1 -60 60;
-    7   10  0.04    0.12    0.03    100   100   100     0       0       1 -60 60;
-    8   9   0.01    0.03    0.02    100   100   100     0       0       1 -60 60;
-    9   10  0.08    0.24    0.05    100   100   100     0       0       1 -60 60;
-];
-
-
-%% dc grid topology
-%colunm_names% dcpoles
-mpc.dcpol=2;
-% numbers of poles (1=monopolar grid, 2=bipolar grid)
-%% bus data
-%column_names%   busdc_i grid    Pdc     Vdc     basekVdc    Vdcmax  Vdcmin  Cdc
-mpc.busdc = [
-  1              1       0       1       345         1.1     0.9     0;
-  2              1       0       1       345         1.1     0.9     0;
-	3              1       0       1       345         1.1     0.9     0;
-	4              1       0       1       345         1.1     0.9     0;
-
-];
-
-%% converters
-%column_names%   busdc_i busac_i type_dc type_ac P_g   Q_g   islcc Vtar    rtf xtf  transformer tm   bf filter    rc      xc  reactor   basekVac    Vmmax   Vmmin   Imax    status   LossA LossB  LossCrec LossCinv  droop      Pdcset    Vdcset  dVdcset Pacmax Pacmin Qacmax Qacmin conv_confi connect_at ground_type ground_z
-mpc.convdc = [
-    1       2   2       1       -60    -40    0 1     0.01  0.01 1 1 0.01 1 0.01   0.01 1  345         1.1     0.9     1.1     1       1.103 0.887  2.885    1.885      0.0050    -58.6274   1.0079   0 100 -100 50 -50 2 0 1 0.5 ;
-    2       7   1       1       0       0     0 1     0.01  0.01 1 1 0.01 1 0.01   0.01 1  345         1.1     0.9     1.1     1       1.103 0.887  2.885    2.885      0.0070     21.9013   1.0000   0 100 -100 50 -50 2 0 0 0.5 ;
-		3      11   1       1       0       0     0 1     0.01  0.01 1 1 0.01 1 0.01   0.01 1  345         1.1     0.9     1.1     1       1.103 0.887  2.885    2.885      0.0070     21.9013   1.0000   0 100 -100 50 -50 1 2 0 0.5 ;
-];
-
-%% branches
-%column_names%   fbusdc  tbusdc  r      l        c   rateA   rateB   rateC   status line_confi return_type return_z connect_at
-mpc.branchdc = [
-  1       4       0.052   0   0    100     100     100     1  2 2 0.052 0;  %bipolar
-	2       4       0.052   0   0    100     100     100     1  2 2 0.052 0;  %bipolar
-	3       4       0.052   0   0     50      50      50     1  1 2 0.052 2;  %monopolar
- ];
-
-%% generator cost data
-%	1	startup	shutdown	n	x1	y1	...	xn	yn
-%	2	startup	shutdown	n	c(n-1)	...	c0
+%% generator cost
+% 1 startup shutdown n x1 y1 ... xn yn
+% 2 startup shutdown n c(n-1) ... c0
 mpc.gencost = [
-	2	0	0	3	0  1	0;
-	2	0	0	3	0  3.5	0;
-  2	0	0	3	0  2.0	0;
-	2	0	0	3 0	 5	0;
-	2	0	0	3 0	 7	0;
+  2       0        0 2 1   0;
+  2       0        0 2 3.5 0;
+  2       0        0 2 2.0 0;
+  2       0        0 2 5   0;
+  2       0        0 2 7   0;
 ];
 
-% adds current ratings to branch matrix
-%column_names%	c_rating_a
+%% AC branch
+% fbus tbus    r    x    b rateA rateB rateC ratio angle status angmin angmax
+mpc.branch = [
+     1    2 0.02 0.06 0.06   100   100   100     0     0      1    -60     60;
+     1    3 0.08 0.24 0.05   100   100   100     0     0      1    -60     60;
+     2    3 0.06 0.18 0.04   100   100   100     0     0      1    -60     60;
+     2    4 0.06 0.18 0.04   100   100   100     0     0      1    -60     60;
+     2    5 0.04 0.12 0.03   100   100   100     0     0      1    -60     60;
+     3    4 0.01 0.03 0.02   100   100   100     0     0      1    -60     60;
+     4    5 0.08 0.24 0.05   100   100   100     0     0      1    -60     60;
+     6    7 0.02 0.06 0.06   100   100   100     0     0      1    -60     60;
+     6    8 0.08 0.24 0.05   100   100   100     0     0      1    -60     60;
+     7    8 0.06 0.18 0.04   100   100   100     0     0      1    -60     60;
+     7    9 0.06 0.18 0.04   100   100   100     0     0      1    -60     60;
+     7   10 0.04 0.12 0.03   100   100   100     0     0      1    -60     60;
+     8    9 0.01 0.03 0.02   100   100   100     0     0      1    -60     60;
+     9   10 0.08 0.24 0.05   100   100   100     0     0      1    -60     60;
+];
+
+%column_names% c_rating_a
 mpc.branch_currents = [
-100;100;100;100;100;100;100;100;100;100;100;100;100;100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+                      100;
+];
+
+%% DC bus
+%column_names% busdc_i grid Pdc Vdc basekVdc Vdcmax Vdcmin Cdc
+mpc.busdc = [
+                     1    1   0   1      345    1.1    0.9   0;
+                     2    1   0   1      345    1.1    0.9   0;
+                     3    1   0   1      345    1.1    0.9   0;
+                     4    1   0   1      345    1.1    0.9   0;
+];
+
+%% converter
+%column_names% busdc_i busac_i type_dc type_ac P_g Q_g islcc Vtar  rtf xtf transformer tm   bf filter   rc   xc reactor basekVac Vmmax Vmmin Imax status LossA LossB LossCrec LossCinv  droop   Pdcset Vdcset dVdcset Pacmax Pacmin Qacmax Qacmin conv_confi connect_at ground_type ground_z
+mpc.convdc = [
+                     1       2       2       1 -60 -40     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    1.885 0.0050 -58.6274 1.0079       0    100   -100     50    -50          2          0           1      0.5;
+                     2       7       1       1   0   0     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    2.885 0.0070  21.9013 1.0000       0    100   -100     50    -50          2          0           0      0.5;
+                     3      11       1       1   0   0     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    2.885 0.0070  21.9013 1.0000       0    100   -100     50    -50          1          2           0      0.5;
+];
+
+%% DC branch
+%column_names% fbusdc tbusdc     r l c rateA rateB rateC status line_confi return_type return_z connect_at
+mpc.branchdc = [
+                    1      4 0.052 0 0   100   100   100      1          2           2    0.052          0; % bipolar
+                    2      4 0.052 0 0   100   100   100      1          2           2    0.052          0; % bipolar
+                    3      4 0.052 0 0    50    50    50      1          1           2    0.052          2; % monopolar
 ];


### PR DESCRIPTION
Closes #6.

See commit messages for details.

You can preview the documentation locally as per instructions reported in the new [README](https://github.com/Electa-Git/PowerModelsMCDC.jl/blob/8f4bc2f158bb503d02c955d87224083618afa8e1/docs/README.md) of the docs project.