### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     - cron:  '0 0 * * 3' # on every Wednesday
 jobs:
   test:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -15,7 +14,6 @@ jobs:
         version: # Julia version
           - '1.6' # LTS release, automatically expands to the latest stable 1.6.x release
           - '1' # current stable release, automatically expands to the latest stable 1.x release
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:
@@ -37,11 +35,9 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-        continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-runtest@v1
         with:
           annotate: true
-        continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
I am incorporating some changes that have already been made in FlexPlan.jl.

- I removed an instruction for skipping CI based on a specific commit message, which was copied from PowerModels. This instruction contained a syntax error. CI can still be skipped when desired, as explained [here](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs).
- I am discontinuing testing on the Julia nightly build as it doesn't provide significant added value. This same change has been applied to PowerModels as well. We will continue testing on the latest stable release and the latest LTS release.