### PR TITLE
Model multi-conductor component status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - This changelog
+- Fixed DCP formulation
+- Multi-conductor status parameters for `convdc` and `branchdc` components
 
 ## [0.1.0] - 2023-07-15
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,7 @@ using Documenter, PowerModelsMCDC
 makedocs(
     modules = [PowerModelsMCDC],
     sitename = "PowerModelsMCDC",
+    warnonly = :missing_docs,
     pages = [
         "Home" => "index.md"
         "Manual" => [

--- a/docs/src/man/network-data.md
+++ b/docs/src/man/network-data.md
@@ -14,8 +14,13 @@ CurrentModule = PowerModelsMCDC
 
 Since PowerModelsMCDC extends the
 [PowerModelsACDC data format](https://electa-git.github.io/PowerModelsACDC.jl/dev/parser/),
-most of the parameters have the same meaning as in PowerModelsACDC.
-The remaining parameters are described below.
+most of the parameters have the same meaning as in PowerModelsACDC. In particular, the
+`status` parameter of `branchdc` and `convdc` components determines whether to include the
+element in the model. If the component is active (i.e., `status = 1`),
+additional parameters control the availability of the single conductors/poles of the
+multi-conductor element. This guarantees portability with PowerModelsACDC.
+
+The parameters that are introduced in PowerModelsMCDC are described below.
 
 
 ### Converter (`convdc`)
@@ -26,6 +31,18 @@ The remaining parameters are described below.
 | `connect_at`  | {0,1,2} |           | Bus terminals where the converter is connected (only used if the converter is monopolar):``\\``0: positive and negative``\\``1: positive and neutral``\\``2: negative and neutral |
 | `ground_type` | {0,1}   |           | Neutral terminal grounding type:``\\``0: ungrounded neutral terminal``\\``1: grounded neutral terminal |
 | `ground_z`    | [0,+∞)  | p.u.      | Grounding impedance (only used if `ground_type == 1`) |
+| `status_p`    | {0,1}   |           | Status of the positive pole of the converter:``\\``0: inactive``\\``1: active |
+| `status_n`    | {0,1}   |           | Status of the negative pole of the converter:``\\``0: inactive``\\``1: active |
+
+Both parameters `status_p` and `status_n` are used for a bipolar converter (i.e., `conv_confi = 2`).
+Instead, a single status parameter is selected if the converter is monopolar (i.e., `conv_confi = 1`),
+depending on its specific configuration:
+
+- In **symmetric** configuration (i.e., `connect_at = 0`), the `status_p` parameter is used by default.
+- In **asymmetric** configuration (i.e., `connect_at` set at `1` or `2`), the status parameter
+  is chosen according to the positive/negative DC bus terminal to which the converter is connected.
+  For example, parameter `status_p` is used if the monopolar converter is connected to the positive
+  DC bus terminal.
 
 
 ### DC branch (`branchdc`)
@@ -36,7 +53,11 @@ The remaining parameters are described below.
 | `connect_at`  | {0,1,2} |           | Bus terminals where the branch is connected (only used if the DC branch is monopolar):``\\``0: positive and negative``\\``1: positive and neutral``\\``2: negative and neutral |
 | `return_type` |         |           | **Not used in package code, but present in input files.**``\\``Originally meant for modeling ground return (1) instead of metallic return (2). |
 | `return_z`    | (0,+∞)  | p.u.      | Metallic return impedance                          |
+| `status_p`    | {0,1}   |           | Status of the positive conductor:``\\``0: inactive``\\``1: active |
+| `status_n`    | {0,1}   |           | Status of the negative conductor:``\\``0: inactive``\\``1: active |
+| `status_r`    | {0,1}   |           | Status of the metallic return:``\\``0: inactive``\\``1: active |
 
+The DC bus terminals, which the DC branch is connected to, determine which status parameters are selected.
 
 ## Working with Matpower files
 

--- a/src/PowerModelsMCDC.jl
+++ b/src/PowerModelsMCDC.jl
@@ -29,6 +29,7 @@ include("core/multiconductor.jl")
 include("core/constraint_template.jl")
 include("core/variable_mcdcgrid.jl")
 include("core/variableconv_mc.jl")
+include("core/solution.jl")
 
 include("formdcgrid/dcp.jl")
 include("formconv/dcp.jl")

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -8,19 +8,18 @@ sum(p_dcgrid[a] for a in bus_arcs_dcgrid) + sum(pconv_dc[c] for c in bus_convs_d
 ```
 """
 
-function constraint_kcl_shunt_dcgrid(pm::_PM.AbstractPowerModel, n::Int, i::Int, bus_arcs_dcgrid, bus_convs_dc, pd, total_cond)
+function constraint_kcl_shunt_dcgrid(pm::_PM.AbstractPowerModel, n::Int, i::Int, pd, total_cond, bus_arcs_dcgrid_cond, bus_convs_dc_cond, bus_convs_grounding_shunt)
     i_dcgrid = _PM.var(pm, n, :i_dcgrid)
     iconv_dc = _PM.var(pm, n, :iconv_dc)
-
     iconv_dcg_shunt = _PM.var(pm, n, :iconv_dcg_shunt)
-
-    bus_arcs_dcgrid_cond = _PM.ref(pm, n, :bus_arcs_dcgrid_cond)
-    bus_convs_dc_cond = _PM.ref(pm, n, :bus_convs_dc_cond)
-    bus_convs_grounding_shunt = _PM.ref(pm, n, :bus_convs_grounding_shunt)
     "load (-pd[k] excluded), to be thought later"
 
-    for k = 1:total_cond
-        JuMP.@constraint(pm.model, sum(i_dcgrid[c][d] for (c, d) in bus_arcs_dcgrid_cond[(i, k)]) + sum(iconv_dc[c][d] for (c, d) in bus_convs_dc_cond[(i, k)]) + sum(iconv_dcg_shunt[c] for c in bus_convs_grounding_shunt[(i, k)]) == 0)
+    for bus_cond in 1:total_cond
+        JuMP.@constraint(pm.model,
+            sum(i_dcgrid[conv][conv_cond] for (conv, conv_cond) in bus_arcs_dcgrid_cond[(i, bus_cond)])
+            + sum(iconv_dc[conv][conv_cond] for (conv, conv_cond) in bus_convs_dc_cond[(i, bus_cond)])
+            + sum(iconv_dcg_shunt[conv] for conv in bus_convs_grounding_shunt[(i, bus_cond)]) == 0
+            )
     end
 end
 
@@ -33,6 +32,5 @@ end
 "`qconv[i] == qconv`"
 function constraint_reactive_conv_setpoint(pm::_PM.AbstractPowerModel, n::Int, i, qconv_cond, cond)
     qconv_var = _PM.var(pm, n, :qconv_tf_fr, i)
-
     JuMP.@constraint(pm.model, qconv_var[cond] == -qconv_cond)
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -1,5 +1,6 @@
 constraint_voltage_dc(pm::_PM.AbstractPowerModel) = constraint_voltage_dc(pm, _PM.nw_id_default)
 # no data, so no further templating is needed, constraint goes directly to the formulations
+
 function constraint_kcl_shunt(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     bus = _PM.ref(pm, nw, :bus, i)
     bus_arcs = _PM.ref(pm, nw, :bus_arcs, i)
@@ -19,11 +20,12 @@ function constraint_kcl_shunt(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw
 end
 
 function constraint_kcl_shunt_dcgrid(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
-    bus_arcs_dcgrid = _PM.ref(pm, nw, :bus_arcs_dcgrid, i)
-    bus_convs_dc = _PM.ref(pm, nw, :bus_convs_dc, i)
-    pd = _PM.ref(pm, nw, :busdc, i)["Pdc"]
-    total_cond = _PM.ref(pm, nw, :busdc, i)["conductors"]
-    constraint_kcl_shunt_dcgrid(pm, nw, i, bus_arcs_dcgrid, bus_convs_dc, pd, total_cond)
+    busdc = _PM.ref(pm, nw, :busdc, i)
+    bus_arcs_dcgrid_cond = _PM.ref(pm, nw, :bus_arcs_dcgrid_cond)
+    bus_convs_dc_cond = _PM.ref(pm, nw, :bus_convs_dc_cond)
+    bus_convs_grounding_shunt = _PM.ref(pm, nw, :bus_convs_grounding_shunt)
+
+    constraint_kcl_shunt_dcgrid(pm, nw, i, busdc["Pdc"], busdc["conductors"], bus_arcs_dcgrid_cond, bus_convs_dc_cond, bus_convs_grounding_shunt)
 end
 
 function constraint_ohms_dc_branch(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
@@ -42,74 +44,92 @@ function constraint_converter_losses(pm::_PM.AbstractPowerModel, i::Int; nw::Int
     a = conv["LossA"]
     b = conv["LossB"]
     c = conv["LossCinv"]
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i)) 
+    for cond in active_pole
         plmax = conv["LossA"][cond] + conv["LossB"][cond] * conv["Pacrated"][cond] + conv["LossCinv"][cond] * (conv["Pacrated"][cond])^2
         constraint_converter_losses(pm, nw, i, a[cond], b[cond], c[cond], plmax, cond)
     end
 end
 
 function constraint_converter_dc_ground_shunt_ohm(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default)
-    constraint_converter_dc_ground_shunt_ohm(pm, nw)
+    bus_convs_grounding_shunt = _PM.ref(pm, nw, :bus_convs_grounding_shunt)
+    r_earth = 0.0
+
+    constraint_converter_dc_ground_shunt_ohm(pm, nw, bus_convs_grounding_shunt, r_earth)
 end
 
 function constraint_converter_current(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     conv = _PM.ref(pm, nw, :convdc, i)
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i))
+    for cond in active_pole
         Vmax = conv["Vmmax"][cond]
         Imax = conv["Imax"][cond]
         constraint_converter_current(pm, nw, i, Vmax, Imax, cond)
     end
 end
 
+function constraint_dc_voltage_magnitude_setpoint(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
+    conv = _PM.ref(pm, nw, :convdc, i)
+    bus_convs_dc_cond = _PM.ref(pm, n, :bus_convs_dc_cond)
+
+    constraint_dc_voltage_magnitude_setpoint(pm, nw, i, conv["busdc_i"], conv["Vdcset"], bus_convs_dc_cond)
+end
+
 function constraint_converter_dc_current(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
-    constraint_converter_dc_current(pm, nw, i)
+    conv = _PM.ref(pm, nw, :convdc, i)
+    busdc = _PM.ref(pm, nw, :busdc, conv["busdc_i"])
+    bus_convs_dc_cond = _PM.ref(pm, nw, :bus_convs_dc_cond)
+
+    bus_cond_convs_dc_cond = Dict(c => bus_convs_dc_cond[(conv["busdc_i"], c)] for c in 1:busdc["conductors"])
+    vdcm = [c == 3 ? -0.0 : sign(busdc["Vdcmin"][c]) for c in 1:busdc["conductors"]]
+
+    constraint_converter_dc_current(pm, nw, i, conv["busdc_i"], vdcm, bus_cond_convs_dc_cond)
 end
 
 function constraint_active_conv_setpoint(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     conv = _PM.ref(pm, nw, :convdc, i)
-
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i))
+    for cond in active_pole
         constraint_active_conv_setpoint(pm, nw, i, conv["P_g"][cond], cond)
     end
 end
 
 function constraint_reactive_conv_setpoint(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     conv = _PM.ref(pm, nw, :convdc, i)
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i))
+    for cond in active_pole
         constraint_reactive_conv_setpoint(pm, nw, i, conv["Q_g"][cond], cond)
     end
-end
-""
-function constraint_dc_voltage_magnitude_setpoint(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
-    constraint_dc_voltage_magnitude_setpoint(pm, nw, i)
 end
 
 function constraint_conv_reactor(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     conv = _PM.ref(pm, nw, :convdc, i)
-
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i))
+    for cond in active_pole
         constraint_conv_reactor(pm, nw, i, conv["rc"][cond], conv["xc"][cond], Bool(conv["reactor"]), cond)
     end
 end
 
 function constraint_conv_filter(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     conv = _PM.ref(pm, nw, :convdc, i)
-
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i))
+    for cond in active_pole
         constraint_conv_filter(pm, nw, i, conv["bf"][cond], Bool(conv["filter"]), cond)
     end
 end
 
 function constraint_conv_transformer(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     conv = _PM.ref(pm, nw, :convdc, i)
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i))
+    for cond in active_pole
         constraint_conv_transformer(pm, nw, i, conv["rtf"][cond], conv["xtf"][cond], conv["busac_i"], conv["tm"][cond], Bool(conv["transformer"]), cond)
     end
 end
 
 function constraint_conv_firing_angle(pm::_PM.AbstractPowerModel, i::Int; nw::Int=_PM.nw_id_default)
     conv = _PM.ref(pm, nw, :convdc, i)
-    for cond in 1:conv["conductors"]
+    active_pole = first(_PM.ref(pm, nw, :convs_ac_cond, i))
+    for cond in active_pole
         S = conv["Pacrated"][cond]
         P1 = cos(0) * S
         Q1 = sin(0) * S
@@ -117,5 +137,4 @@ function constraint_conv_firing_angle(pm::_PM.AbstractPowerModel, i::Int; nw::In
         Q2 = sin(pi) * S
         constraint_conv_firing_angle(pm, nw, i, S, P1, Q1, P2, Q2, cond)
     end
-
 end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -281,6 +281,8 @@ function check_branchdc_parameters(branchdc)
     @assert(branchdc["rateA"] >= 0)
     @assert(branchdc["rateB"] >= 0)
     @assert(branchdc["rateC"] >= 0)
+    # Convert data from equivalent parallel representation to single pole (in case of bipolar converter)
+    from_equivalent_parallel_data!(branchdc)
     # Check if multi-conductor status parameters are defined
     status = ["status_p", "status_n", "status_r"]
     check = haskey.(Ref(branchdc), status)
@@ -363,6 +365,8 @@ function check_conv_parameters(conv)
     @assert(conv["Qacmax"] >= conv["Qacmin"])
     @assert(conv["Pacrated"] >= 0)
     @assert(conv["Qacrated"] >= 0)
+    # Convert data from equivalent parallel representation to single pole (in case of bipolar converter)
+    from_equivalent_parallel_data!(conv)
     # Check if multi-conductor status parameters are defined
     status = ["status_p", "status_n"]
     check = haskey.(Ref(conv), status)
@@ -374,6 +378,37 @@ function check_conv_parameters(conv)
     elseif sum(check) == 1
         Memento.error(_PM._LOGGER, "Parameter `$(first(status[.!check]))` is not defined for converter $conv_id.")
     end
+end
+
+"Convert equivalent parallel data of bipolar `convdc` and `branchdc` to data for single pole/conductor"
+function from_equivalent_parallel_data!(data)
+
+    if haskey(data, "conv_confi") && data["conv_confi"] == 2
+        data["rtf"] = data["rtf"] * 2
+        data["xtf"] = data["xtf"] * 2
+        data["bf"] = data["bf"] / 2
+        data["rc"] = data["rc"] * 2
+        data["xc"] = data["xc"] * 2
+        data["LossB"] = data["LossB"]
+        data["LossA"] = data["LossA"] / 2
+        data["LossCrec"] = data["LossCrec"] * 2
+        data["LossCinv"] = data["LossCinv"] * 2
+
+        data["Imax"] = data["Imax"] / 2
+        data["Pacmax"] = data["Pacmax"] / 2
+        data["Pacmin"] = data["Pacmin"] / 2
+        data["Pacrated"] = data["Pacrated"] / 2
+
+        data["Qacmax"] = data["Qacmax"] / 2
+        data["Qacmin"] = data["Qacmin"] / 2
+        data["Qacrated"] = data["Qacrated"] / 2
+    
+    elseif haskey(data, "line_confi") && data["line_confi"] == 2
+        data["rateA"] = data["rateA"]  / 2
+        data["rateB"] = data["rateB"] / 2
+        data["rateC"] = data["rateC"] / 2
+    end
+    return nothing
 end
 
 function get_branchdc(matpowerdcline, branch_i, fbusdc, tbusdc)
@@ -519,53 +554,8 @@ end
 
 function build_mc_data!(base_data)
 
-    # Make lossless conv parameters and impedances
-    for (c, conv) in base_data["convdc"]
-        if conv["conv_confi"] == 2
-            conv["rtf"] = 2 * conv["rtf"]
-            conv["xtf"] = 2 * conv["xtf"]
-            conv["bf"] = 0.5 * conv["bf"]
-            conv["rc"] = 2 * conv["rc"]
-            conv["xc"] = 2 * conv["xc"]
-            conv["LossB"] = conv["LossB"]
-            conv["LossA"] = 0.5 * conv["LossA"]
-            conv["LossCrec"] = 2 * conv["LossCrec"]
-            conv["LossCinv"] = 2 * conv["LossCinv"]
-        end
-    end
-
     process_additional_data!(base_data)
-    _make_multiconductor!(base_data)
-
-    # Adjust line limits
-    for (c, bn) in base_data["branchdc"]
-        if bn["line_confi"] == 2
-            bn["rateA"] = bn["rateA"] / 2
-            bn["rateB"] = bn["rateB"] / 2
-            bn["rateC"] = bn["rateC"] / 2
-        end
-        metallic_cond_number = bn["conductors"]
-
-        bn["r"][metallic_cond_number] = bn["return_z"]
-
-    end
-
-    # Adjust converter limits
-    for (c, conv) in base_data["convdc"]
-        if conv["conv_confi"] == 2
-            conv["Pacmax"] = conv["Pacmax"] / 2
-            conv["Pacmin"] = conv["Pacmin"] / 2
-            conv["Pacrated"] = conv["Pacrated"] / 2
-        end
-    end
-
-    # Adjust metallic return bus voltage limits
-    for (i, busdc) in base_data["busdc"]
-        busdc["Vdcmax"][3] = busdc["Vdcmax"][1] - 1.0
-        busdc["Vdcmin"][3] = -(1 - busdc["Vdcmin"][1])
-        busdc["Vdcmax"][2] = -busdc["Vdcmin"][1]
-        busdc["Vdcmin"][2] = -busdc["Vdcmax"][1]
-    end
+    make_multiconductor!(base_data)
 
     return base_data
 end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1,4 +1,11 @@
 
+# Lookup table for monopolar branchdc/convdc "connect_at" parameter to busdc terminals (1, 2 and 3 are positive, negative and neutral respectively)
+const _component_busdc_terminal_lookup = Dict{Int, Vector{Int}}(
+    0 => [1, 2],
+    1 => [1, 3],
+    2 => [2, 3]
+)
+
 function get_pu_bases(MVAbase, kVbase)
     eurobase = 1 #
     hourbase = 1 #

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -1,0 +1,22 @@
+"builds solution structure composed by both variables and fixed values based on multi-conductor status parameter"
+function sol_component_value_status(pm::_PM.AbstractPowerModel, n::Int, comp_name::Symbol, field_name::Symbol, comp_ids, conductors, variables, constant=0.0)
+
+    data = Dict{Int, Any}()
+    for i in comp_ids
+        data[i] = [in(c, first(conductors[i])) ? variables[i][c] : constant for c in 1:last(conductors[i])]
+    end  
+    _PM.sol_component_value(pm, n, comp_name, field_name, comp_ids, data)
+end
+
+"builds solution structure composed by both edge variables and fixed values based on multi-conductor status parameter"
+function sol_component_value_edge_status(pm::_PM.AbstractPowerModel, n::Int, comp_name::Symbol, field_name_fr::Symbol, field_name_to::Symbol, comp_ids_fr, comp_ids_to, conductors, variables, constant=0.0)
+
+    data = Dict{Tuple{Int, Int, Int}, Any}()
+    for (l, i, j) in comp_ids_fr
+        data[(l, i, j)] = [in(c, first(conductors[(l, i, j)])) ? variables[(l, i, j)][c] : constant for c in 1:last(conductors[(l, i, j)])]
+    end
+    for (l, i, j) in comp_ids_to
+        data[(l, i, j)] = [in(c, first(conductors[(l, i, j)])) ? variables[(l, i, j)][c] : constant for c in 1:last(conductors[(l, i, j)])]
+    end
+    _PM.sol_component_value_edge(pm, n, comp_name, field_name_fr, field_name_to, comp_ids_fr, comp_ids_to, data)
+end

--- a/src/formdcgrid/acp.jl
+++ b/src/formdcgrid/acp.jl
@@ -13,8 +13,8 @@ function constraint_kcl_shunt(pm::_PM.AbstractACPModel, n::Int, i::Int, bus_arcs
     pconv_grid_ac = _PM.var(pm, n, :pconv_tf_fr)
     qconv_grid_ac = _PM.var(pm, n, :qconv_tf_fr)
 
-    JuMP.@NLconstraint(pm.model, sum(p[a] for a in bus_arcs) + sum(sum(pconv_grid_ac[c][d] for d in 1:length(_PM.var(pm, n, :pconv_tf_fr, c))) for c in bus_convs_ac) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts) * vm^2)
-    JuMP.@NLconstraint(pm.model, sum(q[a] for a in bus_arcs) + sum(sum(qconv_grid_ac[c][d] for d in 1:length(_PM.var(pm, n, :qconv_tf_fr, c))) for c in bus_convs_ac) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts) * vm^2)
+    JuMP.@NLconstraint(pm.model, sum(p[a] for a in bus_arcs) + sum(sum(pconv_grid_ac[c][d] for d in first(axes(_PM.var(pm, n, :pconv_tf_fr, c)))) for c in bus_convs_ac) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts) * vm^2)
+    JuMP.@NLconstraint(pm.model, sum(q[a] for a in bus_arcs) + sum(sum(qconv_grid_ac[c][d] for d in first(axes(_PM.var(pm, n, :pconv_tf_fr, c)))) for c in bus_convs_ac) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts) * vm^2)
 end
 
 """
@@ -49,19 +49,14 @@ function constraint_ohms_dc_branch(pm::_PM.AbstractACPModel, n::Int, f_bus, t_bu
 end
 
 "`vdc[i] == vdcm`"
-function constraint_dc_voltage_magnitude_setpoint(pm::_PM.AbstractACPModel, n::Int, i)
-
-    conv = _PM.ref(pm, n, :convdc, i)
-    dc_bus = _PM.ref(pm, n, :convdc, i)["busdc_i"]
-    v = _PM.var(pm, n, :vdcm, dc_bus)
-
-    bus_convs_dc_cond = _PM.ref(pm, n, :bus_convs_dc_cond)
-    for k in 1:2
-        for (c, d) in bus_convs_dc_cond[(dc_bus, k)]
-            if c == i
-                JuMP.@constraint(pm.model, v[k] == conv["Vdcset"][d])
+function constraint_dc_voltage_magnitude_setpoint(pm::_PM.AbstractACPModel, n::Int, i, busdc, Vdcset, bus_convs_dc_cond)
+    vdcm = _PM.var(pm, n, :vdcm, busdc)
+    
+    for bus_cond in 1:2
+        for (conv, conv_cond) in bus_convs_dc_cond[(busdc, bus_cond)]
+            if conv == i
+                JuMP.@constraint(pm.model, vdcm[bus_cond] == Vdcset[conv_cond])
             end
         end
     end
-
 end

--- a/src/formdcgrid/acp.jl
+++ b/src/formdcgrid/acp.jl
@@ -14,7 +14,7 @@ function constraint_kcl_shunt(pm::_PM.AbstractACPModel, n::Int, i::Int, bus_arcs
     qconv_grid_ac = _PM.var(pm, n, :qconv_tf_fr)
 
     JuMP.@NLconstraint(pm.model, sum(p[a] for a in bus_arcs) + sum(sum(pconv_grid_ac[c][d] for d in first(axes(_PM.var(pm, n, :pconv_tf_fr, c)))) for c in bus_convs_ac) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts) * vm^2)
-    JuMP.@NLconstraint(pm.model, sum(q[a] for a in bus_arcs) + sum(sum(qconv_grid_ac[c][d] for d in first(axes(_PM.var(pm, n, :pconv_tf_fr, c)))) for c in bus_convs_ac) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts) * vm^2)
+    JuMP.@NLconstraint(pm.model, sum(q[a] for a in bus_arcs) + sum(sum(qconv_grid_ac[c][d] for d in first(axes(_PM.var(pm, n, :qconv_tf_fr, c)))) for c in bus_convs_ac) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts) * vm^2)
 end
 
 """

--- a/src/formdcgrid/dcp.jl
+++ b/src/formdcgrid/dcp.jl
@@ -5,12 +5,12 @@ sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[
 ```
 """
 function constraint_kcl_shunt(pm::_PM.AbstractDCPModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_convs_ac, bus_loads, bus_shunts, pd, qd, gs, bs)
-    vm = 1
     p = _PM.var(pm, n, :p)
     pg = _PM.var(pm, n, :pg)
-    vm = 1
     pconv_grid_ac = _PM.var(pm, n, :pconv_tf_fr)
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(sum(pconv_grid_ac[c][d] for d in 1:length(_PM.var(pm, n, :pconv_tf_fr, c))) for c in bus_convs_ac) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts) * vm^2)
+    vm = 1
+
+    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(sum(pconv_grid_ac[c][d] for d in first(axes(_PM.var(pm, n, :pconv_tf_fr, c)))) for c in bus_convs_ac) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts) * vm^2)
 end
 
 """
@@ -45,6 +45,6 @@ function constraint_ohms_dc_branch(pm::_PM.AbstractDCPModel, n::Int, f_bus, t_bu
 end
 
 "`vdc[i] == vdcm`"
-function constraint_dc_voltage_magnitude_setpoint(pm::_PM.AbstractDCPModel, n::Int, i)
+function constraint_dc_voltage_magnitude_setpoint(pm::_PM.AbstractDCPModel, n::Int, i, busdc, Vdcset, bus_convs_dc_cond)
     # not used
 end

--- a/test/data/matacdc_scripts/case5_2grids_MC.m
+++ b/test/data/matacdc_scripts/case5_2grids_MC.m
@@ -98,17 +98,17 @@ mpc.busdc = [
 ];
 
 %% converter
-%column_names% busdc_i busac_i type_dc type_ac P_g Q_g islcc Vtar  rtf xtf transformer tm   bf filter   rc   xc reactor basekVac Vmmax Vmmin Imax status LossA LossB LossCrec LossCinv  droop   Pdcset Vdcset dVdcset Pacmax Pacmin Qacmax Qacmin conv_confi connect_at ground_type ground_z
+%column_names% busdc_i busac_i type_dc type_ac P_g Q_g islcc Vtar  rtf xtf transformer tm   bf filter   rc   xc reactor basekVac Vmmax Vmmin Imax status LossA LossB LossCrec LossCinv  droop   Pdcset Vdcset dVdcset Pacmax Pacmin Qacmax Qacmin conv_confi connect_at ground_type ground_z status_p status_n
 mpc.convdc = [
-                     1       2       2       1 -60 -40     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    1.885 0.0050 -58.6274 1.0079       0    100   -100     50    -50          2          0           1      0.5;
-                     2       7       1       1   0   0     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    2.885 0.0070  21.9013 1.0000       0    100   -100     50    -50          2          0           0      0.5;
-                     3      11       1       1   0   0     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    2.885 0.0070  21.9013 1.0000       0    100   -100     50    -50          1          2           0      0.5;
+                     1       2       2       1 -60 -40     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    1.885 0.0050 -58.6274 1.0079       0    100   -100     50    -50          2          0           1      0.5        1        1;
+                     2       7       1       1   0   0     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    2.885 0.0070  21.9013 1.0000       0    100   -100     50    -50          2          0           0      0.5        1        1;
+                     3      11       1       1   0   0     0    1 0.01 0.01          1  1 0.01      1 0.01 0.01       1      345   1.1   0.9  1.1      1 1.103 0.887    2.885    2.885 0.0070  21.9013 1.0000       0    100   -100     50    -50          1          2           0      0.5        0        1;
 ];
 
 %% DC branch
-%column_names% fbusdc tbusdc     r l c rateA rateB rateC status line_confi return_type return_z connect_at
+%column_names% fbusdc tbusdc     r l c rateA rateB rateC status line_confi return_type return_z connect_at status_p status_n status_r
 mpc.branchdc = [
-                    1      4 0.052 0 0   100   100   100      1          2           2    0.052          0; % bipolar
-                    2      4 0.052 0 0   100   100   100      1          2           2    0.052          0; % bipolar
-                    3      4 0.052 0 0    50    50    50      1          1           2    0.052          2; % monopolar
+                    1      4 0.052 0 0   100   100   100      1          2           2    0.052          0        1        1        1; % bipolar
+                    2      4 0.052 0 0   100   100   100      1          2           2    0.052          0        1        1        1; % bipolar
+                    3      4 0.052 0 0    50    50    50      1          1           2    0.052          2        0        1        1; % monopolar
 ];


### PR DESCRIPTION
Closes #16.

This PR enables control over the status (i.e., active or inactive) of each conductor in a multi-conductor component. This applies to `branchdc` and `convdc` components.

Hereafter, the main developments are summarized. Further details can be found in the commits.

1. For each DC component of type `branchdc` or `convdc`, a `status` vector is generated by using the values of parameters  `status_p`, `status_n` and `status_r`. The length of the resulting vector depends on the component type and on its configuration (i.e. monopolar or bipolar):
    - For `convdc` component:
      - In monopolar **symmetric** configuration (i.e., `conv_confi = 1` and `connect_at` set to 0), only `status_p` is used by default.
      - In monopolar **asymmetric** configuration (i.e., `conv_confi = 1` and `connect_at` set to 1 or 2), only the status for the relevant pole is used (either positive or negative).
      - In bipolar configuration (i.e., `conv_confi` is equal to 2), both `status_p` and `status_n` are used.
     - For the `branchdc` component, the relevant status values (among `status_p`, `status_n` and `status_r`) are used, depending on the `connect_at` value if the `line_confi` is set to 1. If the line in bipolar, all status values are used.

2. In function `add_ref_dcgrid!`, lookup tables that map from `busdc` conductors to `branchdc` or `convdc` conductors are modified to account only for active conductors. Furthermore, new lookup tables are added to ease JuMP variable definition.
3. Variables and constraint definitions are modified to account only for active conductors of `branchdc` and `convdc` components.