### PR TITLE
Update documentation settings for Documenter v1

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,7 @@ using Documenter, PowerModelsMCDC
 makedocs(
     modules = [PowerModelsMCDC],
     sitename = "PowerModelsMCDC",
+    warnonly = :missing_docs,
     pages = [
         "Home" => "index.md"
         "Manual" => [


### PR DESCRIPTION
`Documenter.makedocs` now fails builds by default if any of the document checks fails.

Several docstrings are presently absent from this package, leading to build failures in Documenter. Although the ultimate goal remains to provide documentation for every exported function, this commit serves as a temporary workaround. It enables Documenter to issue warnings, rather than triggering errors, in instances of missing docstrings.

See also: [Release notes](https://documenter.juliadocs.org/stable/release-notes/#Version-[v1.0.0](https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.0.0)-2023-09-15) of Documenter v1.0.0.