### PR TITLE
Fix `add_ref_dcgrid!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Some lookup tables were not defined in `add_ref_dcgrid!` for AC-only grids
+
 ## [0.1.1] - 2024-01-09
 
 ### Added

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -137,6 +137,10 @@ function add_ref_dcgrid!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
             nw_ref[:bus_convs_dc] = Dict{String,Any}()
             nw_ref[:ref_buses_dc] = Dict{String,Any}()
             nw_ref[:buspairsdc] = Dict{String,Any}()
+            # Component-conductors lookup tables
+            nw_ref[:arcs_dcgrid_cond] = Dict{String,Any}()
+            nw_ref[:convs_ac_cond] = Dict{String,Any}()
+            nw_ref[:convs_dc_cond] = Dict{String,Any}()
         end
     end
 end


### PR DESCRIPTION
In #17 new lookup tables were added in `add_ref_dcgrid!` to manage active conductors. However, these lookup tables were defined only for the case in which HVDC components exist in the given power system, resulting in a PowerModelsMCDC error if a grid that consists only of AC components is given. This pull request fixes this issue.