### PR TITLE
Fix `add_ref_dcgrid!` (again)

### DIFF
--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -135,10 +135,13 @@ function add_ref_dcgrid!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
             end
             nw_ref[:bus_convs_ac] = bus_convs_ac
             nw_ref[:bus_convs_dc] = Dict{String,Any}()
+            nw_ref[:bus_convs_grounding_shunt] = Dict{String,Any}()
             nw_ref[:ref_buses_dc] = Dict{String,Any}()
             nw_ref[:buspairsdc] = Dict{String,Any}()
             # Component-conductors lookup tables
+            nw_ref[:bus_arcs_dcgrid_cond] = Dict{String,Any}()
             nw_ref[:arcs_dcgrid_cond] = Dict{String,Any}()
+            nw_ref[:bus_convs_dc_cond] = Dict{String,Any}()
             nw_ref[:convs_ac_cond] = Dict{String,Any}()
             nw_ref[:convs_dc_cond] = Dict{String,Any}()
         end


### PR DESCRIPTION
Fixes the same issue of PR #25 for a different lookup table.

Now all lookup tables used in `add_ref_dcgrid!` are instantiated as empty if an AC-only power system is given, avoiding this type of error.