### PR TITLE
ADD ACR formulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ All notable changes to PowerModelsMCDC.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
+## prep. [0.2.0] - 2024-08-07
 
 - Some lookup tables were not defined in `add_ref_dcgrid!` for AC-only grids
+- Add ACR formulation
 
 ## [0.1.1] - 2024-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to PowerModelsMCDC.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## prep. [0.2.0] - 2024-08-07
+## [Unreleased] 
+
+### Added
+
+- Added ACR formulation
+
+### Fixed
 
 - Some lookup tables were not defined in `add_ref_dcgrid!` for AC-only grids
-- Add ACR formulation
 
 ## [0.1.1] - 2024-01-09
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "PowerModelsMCDC"
 uuid = "05d58fe5-e6ff-58ad-86d6-05dcc0b74504"
 authors = ["Chandra Kant Jat", "Jay Dave", "Hakan Ergun"]
 repo = "https://github.com/Electa-Git/PowerModelsMCDC.jl"
-version = "0.2.0"
+version = "0.1.1"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
@@ -17,7 +17,7 @@ Ipopt = "1"
 JuMP = "1"
 Memento = "1"
 PowerModels = "0.19.8"
-julia = ">=1.6"
+julia = "1.6"
 
 [extras]
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "PowerModelsMCDC"
 uuid = "05d58fe5-e6ff-58ad-86d6-05dcc0b74504"
 authors = ["Chandra Kant Jat", "Jay Dave", "Hakan Ergun"]
 repo = "https://github.com/Electa-Git/PowerModelsMCDC.jl"
-version = "0.2.1"
+version = "0.2.0"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "PowerModelsMCDC"
 uuid = "05d58fe5-e6ff-58ad-86d6-05dcc0b74504"
 authors = ["Chandra Kant Jat", "Jay Dave", "Hakan Ergun"]
 repo = "https://github.com/Electa-Git/PowerModelsMCDC.jl"
-version = "0.1.1"
+version = "0.2.1"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
@@ -17,7 +17,7 @@ Ipopt = "1"
 JuMP = "1"
 Memento = "1"
 PowerModels = "0.19.8"
-julia = "1.6"
+julia = ">=1.6"
 
 [extras]
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"

--- a/src/PowerModelsMCDC.jl
+++ b/src/PowerModelsMCDC.jl
@@ -1,63 +1,65 @@
 module PowerModelsMCDC
 
 
-## Imports
+    ## Imports
 
-import Memento
-import JuMP
-import InfrastructureModels as _IM
-import PowerModels as _PM
-
-
-## Memento settings
-
-# Create our module level logger (this will get precompiled)
-const _LOGGER = Memento.getlogger(@__MODULE__)
-
-# Register the module level logger at runtime so that folks can access the logger via `getlogger(PowerModelsMCDC)`
-# NOTE: If this line is not included then the precompiled `PowerModelsMCDC._LOGGER` won't be registered at runtime.
-__init__() = Memento.register(_LOGGER)
+    import Memento
+    import JuMP
+    import InfrastructureModels as _IM
+    import PowerModels as _PM
 
 
-## Includes
+    ## Memento settings
 
-include("core/data.jl")
-include("core/base.jl")
-include("core/constraint.jl")
-include("core/objective.jl")
-include("core/multiconductor.jl")
-include("core/constraint_template.jl")
-include("core/variable_mcdcgrid.jl")
-include("core/variableconv_mc.jl")
-include("core/solution.jl")
+    # Create our module level logger (this will get precompiled)
+    const _LOGGER = Memento.getlogger(@__MODULE__)
 
-include("formdcgrid/dcp.jl")
-include("formconv/dcp.jl")
-
-include("formdcgrid/acp.jl")
-include("formconv/acp.jl")
-
-include("prob/mcdcopf.jl")
-
-include("io/parse.jl")
+    # Register the module level logger at runtime so that folks can access the logger via `getlogger(PowerModelsMCDC)`
+    # NOTE: If this line is not included then the precompiled `PowerModelsMCDC._LOGGER` won't be registered at runtime.
+    __init__() = Memento.register(_LOGGER)
 
 
-## Exports
+    ## Includes
 
-# The following items are exported for user-friendlyness when calling
-# `using PowerModelsMCDC`, so that users do not need to import JuMP to use a solver with
-# PowerModelsMCDC.
-import JuMP: optimizer_with_attributes
-export optimizer_with_attributes
+    include("core/data.jl")
+    include("core/base.jl")
+    include("core/constraint.jl")
+    include("core/objective.jl")
+    include("core/multiconductor.jl")
+    include("core/constraint_template.jl")
+    include("core/variable_mcdcgrid.jl")
+    include("core/variableconv_mc.jl")
+    include("core/solution.jl")
 
-import JuMP: TerminationStatusCode, ResultStatusCode
-export TerminationStatusCode, ResultStatusCode
+    include("formdcgrid/acp.jl")
+    include("formdcgrid/dcp.jl")
 
-for status_code_enum in [TerminationStatusCode, ResultStatusCode]
-    for status_code in instances(status_code_enum)
-        @eval import JuMP: $(Symbol(status_code))
-        @eval export $(Symbol(status_code))
+    include("formconv/acp.jl")
+    include("formconv/acr.jl")
+    include("formconv/dcp.jl")
+    include("formconv/shared.jl")
+
+    include("prob/mcdcopf.jl")
+
+    include("io/parse.jl")
+
+
+    ## Exports
+
+    # The following items are exported for user-friendlyness when calling
+    # `using PowerModelsMCDC`, so that users do not need to import JuMP to use a solver with
+    # PowerModelsMCDC.
+    import JuMP: optimizer_with_attributes
+    export optimizer_with_attributes
+
+    import JuMP: TerminationStatusCode, ResultStatusCode
+    export TerminationStatusCode, ResultStatusCode
+
+    for status_code_enum in [TerminationStatusCode, ResultStatusCode]
+        for status_code in instances(status_code_enum)
+            @eval import JuMP: $(Symbol(status_code))
+            @eval export $(Symbol(status_code))
+        end
     end
-end
 
 end

--- a/src/core/variableconv_mc.jl
+++ b/src/core/variableconv_mc.jl
@@ -369,7 +369,7 @@ function variable_acside_current(pm::_PM.AbstractWModels; nw::Int=_PM.nw_id_defa
     report && _PM.sol_component_value(pm, nw, :convdc, :iconv_ac_sq, _PM.ids(pm, nw, :convdc), icsq)
 end
 
-function variable_converter_filter_voltage(pm::Union{_PM.AbstractACPModel, _PM.DCPPowerModel}; kwargs...)
+function variable_converter_filter_voltage(pm::_PM.AbstractPowerModel; kwargs...)
     variable_converter_filter_voltage_magnitude(pm; kwargs...)
     variable_converter_filter_voltage_angle(pm; kwargs...)
 end
@@ -459,7 +459,7 @@ function variable_converter_filter_voltage_imaginary(pm::_PM.AbstractPowerModel;
     report && sol_component_value_status(pm, nw, :convdc, :vifilt, _PM.ids(pm, nw, :convdc), conductors, vars)
 end
 
-function variable_converter_internal_voltage(pm::Union{_PM.AbstractACPModel, _PM.DCPPowerModel}; kwargs...)
+function variable_converter_internal_voltage(pm::_PM.AbstractPowerModel; kwargs...)
     variable_converter_internal_voltage_magnitude(pm; kwargs...)
     variable_converter_internal_voltage_angle(pm; kwargs...)
 end

--- a/src/formconv/acr.jl
+++ b/src/formconv/acr.jl
@@ -71,7 +71,7 @@ p_pr_fr ==  gc *(vrf^2 + vif^2) + -gc *(vrc * vrf + vic * vif) + -bc *(-(vic * v
 q_pr_fr == -bc *(vrf^2 + vif^2) +  bc *(vrc * vrf + vic * vif) + -gc *(-(vic * vrf - vrc * vif))
 ```
 """
-function constraint_conv_reactor(pm::_PM.AbstractACRModel, n::Int, i::Int, rc, xc, reactor)
+function constraint_conv_reactor(pm::_PM.AbstractACRModel, n::Int, i::Int, rc, xc, reactor, cond)
     pconv_ac = _PM.var(pm, n,  :pconv_ac, i)[cond]
     qconv_ac = _PM.var(pm, n,  :qconv_ac, i)[cond]
     ppr_fr = _PM.var(pm, n,  :pconv_pr_fr, i)[cond]
@@ -107,7 +107,7 @@ ppr_fr + ptf_to == 0
 qpr_fr + qtf_to +  (-bv) * filter *(vrf^2 + vif^2) == 0
 ```
 """
-function constraint_conv_filter(pm::_PM.AbstractACRModel, n::Int, i::Int, bv, filter)
+function constraint_conv_filter(pm::_PM.AbstractACRModel, n::Int, i::Int, bv, filter, cond)
     ppr_fr = _PM.var(pm, n, :pconv_pr_fr, i)[cond]
     qpr_fr = _PM.var(pm, n, :qconv_pr_fr, i)[cond]
     ptf_to = _PM.var(pm, n, :pconv_tf_to, i)[cond]

--- a/src/formconv/acr.jl
+++ b/src/formconv/acr.jl
@@ -1,0 +1,121 @@
+"""
+Links converter power & current
+```
+pconv_ac[i]^2 + pconv_dc[i]^2 == (vrc[i]^2 + vic[i]^2) * iconv_sq[i]
+```
+"""
+function constraint_converter_current(pm::_PM.AbstractACRModel, n::Int, i::Int, Umax, Imax, cond)
+    vrc = _PM.var(pm, n, :vrc, i)[cond]
+    vic = _PM.var(pm, n, :vic, i)[cond]
+    pconv_ac = _PM.var(pm, n, :pconv_ac, i)[cond]
+    qconv_ac = _PM.var(pm, n, :qconv_ac, i)[cond]
+    iconv = _PM.var(pm, n, :iconv_ac, i)[cond]
+
+    JuMP.@NLconstraint(pm.model, pconv_ac^2 + qconv_ac^2 == (vrc^2+vic^2) * iconv^2)
+end
+"""
+Converter transformer constraints
+```
+p_tf_fr ==  g/(tm^2)*(vr_fr^2+vi_fr^2) + -g/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -b/(tm)*(vi_fr*vr_to-vr_fr*vi*to)
+q_tf_fr == -b/(tm^2)*(vr_fr^2+vi_fr^2) +  b/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -g/(tm)*(vi_fr*vr_to-vr_fr*vi*to)
+p_tf_to ==  g*(vr_to^2+vi_to^2)        + -g/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -b/(tm)*(-(vi_fr*vr_to-vr_fr*vi*to))
+q_tf_to == -b*(vr_to^2+vi_to^2)        +  b/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -g/(tm)*(-(vi_fr*vr_to-vr_fr*vi*to))
+```
+"""
+function constraint_conv_transformer(pm::_PM.AbstractACRModel, n::Int, i::Int, rtf, xtf, acbus, tm, transformer, cond)
+    ptf_fr = _PM.var(pm, n, :pconv_tf_fr, i)[cond]
+    qtf_fr = _PM.var(pm, n, :qconv_tf_fr, i)[cond]
+    ptf_to = _PM.var(pm, n, :pconv_tf_to, i)[cond]
+    qtf_to = _PM.var(pm, n, :qconv_tf_to, i)[cond]
+
+    vr = _PM.var(pm, n, :vr, acbus) # why do these have no ``cond" idx?
+    vi = _PM.var(pm, n, :vi, acbus) # why do these have no ``cond" idx?
+    vrf = _PM.var(pm, n, :vrf, i)[cond]
+    vif = _PM.var(pm, n, :vif, i)[cond] 
+
+    # ztf = rtf + im * xtf
+    if transformer
+        ytf = 1 / (rtf + im * xtf)
+        gtf = real(ytf)
+        btf = imag(ytf)
+        gtf_sh = 0
+        ac_power_flow_constraints(pm, gtf, btf, gtf_sh, vr, vrf, vi, vif, ptf_fr, ptf_to, qtf_fr, qtf_to, tm)
+    else
+        JuMP.@constraint(pm.model, ptf_fr + ptf_to == 0)
+        JuMP.@constraint(pm.model, qtf_fr + qtf_to == 0)
+        JuMP.@constraint(pm.model, vr == vrf)
+        JuMP.@constraint(pm.model, vi == vif)
+    end
+end
+"""
+Converter transformer constraints
+```
+p_tf_fr ==  g/(tm^2)*(vr_fr^2+vi_fr^2) + -g/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -b/(tm)*(vi_fr*vr_to-vr_fr*vi*to)
+q_tf_fr == -b/(tm^2)*(vr_fr^2+vi_fr^2) +  b/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -g/(tm)*(vi_fr*vr_to-vr_fr*vi*to)
+p_tf_to ==  g*(vr_to^2+vi_to^2)        + -g/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -b/(tm)*(-(vi_fr*vr_to-vr_fr*vi*to))
+q_tf_to == -b*(vr_to^2+vi_to^2)        +  b/(tm)*(vr_fr*vr_to + vi_fr*vi_to) + -g/(tm)*(-(vi_fr*vr_to-vr_fr*vi*to))
+```
+"""
+function ac_power_flow_constraints(pm::_PM.AbstractACRModel, g, b, gsh_fr, vr, vrf, vi, vif, p_fr, p_to, q_fr, q_to, tm)
+    JuMP.@NLconstraint(pm.model, p_fr ==  g / tm^2 * (vr^2 + vi^2) + -g / tm * (vr * vrf + vi * vif) + -b / tm *   (vi * vrf - vr * vif)  )
+    JuMP.@NLconstraint(pm.model, q_fr == -b / tm^2 * (vr^2 + vi^2) +  b / tm * (vr * vrf + vi * vif) + -g / tm *   (vi * vrf - vr * vif)  )
+    JuMP.@NLconstraint(pm.model, p_to ==  g * (vrf^2 + vif^2)      + -g / tm * (vr * vrf + vi * vif) + -b / tm * (-(vi * vrf - vr * vif)) )
+    JuMP.@NLconstraint(pm.model, q_to == -b * (vrf^2 + vif^2)      +  b / tm * (vr * vrf + vi * vif) + -g / tm * (-(vi * vrf - vr * vif)) )
+end
+"""
+Converter reactor constraints
+```
+-pconv_ac == gc*(vrc^2 + vic^2) + -gc*(vrc * vrf + vic * vif) + -bc*(vic * vrf - vrc * vif)
+-qconv_ac ==-bc*(vrc^2 + vic^2) +  bc*(vrc * vrf + vic * vif) + -gc*(vic * vrf - vrc * vif)
+p_pr_fr ==  gc *(vrf^2 + vif^2) + -gc *(vrc * vrf + vic * vif) + -bc *(-(vic * vrf - vrc * vif))
+q_pr_fr == -bc *(vrf^2 + vif^2) +  bc *(vrc * vrf + vic * vif) + -gc *(-(vic * vrf - vrc * vif))
+```
+"""
+function constraint_conv_reactor(pm::_PM.AbstractACRModel, n::Int, i::Int, rc, xc, reactor)
+    pconv_ac = _PM.var(pm, n,  :pconv_ac, i)[cond]
+    qconv_ac = _PM.var(pm, n,  :qconv_ac, i)[cond]
+    ppr_fr = _PM.var(pm, n,  :pconv_pr_fr, i)[cond]
+    qpr_fr = _PM.var(pm, n,  :qconv_pr_fr, i)[cond]
+
+    vrf = _PM.var(pm, n, :vrf, i)[cond] 
+    vif = _PM.var(pm, n, :vif, i)[cond] 
+    vrc = _PM.var(pm, n, :vrc, i)[cond] 
+    vic = _PM.var(pm, n, :vic, i)[cond] 
+
+    # zc = rc + im*xc
+    if reactor
+        yc = 1/(rc + im*xc)
+        gc = real(yc)
+        bc = imag(yc)                                      
+        JuMP.@constraint(pm.model, - pconv_ac ==  gc * (vrc^2 + vic^2) + -gc * (vrc * vrf + vic * vif) + -bc * (vic * vrf - vrc * vif))  
+        JuMP.@constraint(pm.model, - qconv_ac == -bc * (vrc^2 + vic^2) +  bc * (vrc * vrf + vic * vif) + -gc * (vic * vrf - vrc * vif)) 
+        JuMP.@constraint(pm.model, ppr_fr ==  gc * (vrf^2 + vif^2) + -gc * (vrc * vrf + vic * vif) + -bc * (-(vic * vrf - vrc * vif)))
+        JuMP.@constraint(pm.model, qpr_fr == -bc * (vrf^2 + vif^2) +  bc * (vrc * vrf + vic * vif) + -gc * (-(vic * vrf - vrc * vif)))
+    else
+        ppr_to = - pconv_ac
+        qpr_to = - qconv_ac
+        JuMP.@constraint(pm.model, ppr_fr + ppr_to == 0)
+        JuMP.@constraint(pm.model, qpr_fr + qpr_to == 0)
+        JuMP.@constraint(pm.model, vrc == vrf)
+        JuMP.@constraint(pm.model, vic == vif)
+    end
+end
+"""
+Converter filter constraints
+```
+ppr_fr + ptf_to == 0
+qpr_fr + qtf_to +  (-bv) * filter *(vrf^2 + vif^2) == 0
+```
+"""
+function constraint_conv_filter(pm::_PM.AbstractACRModel, n::Int, i::Int, bv, filter)
+    ppr_fr = _PM.var(pm, n, :pconv_pr_fr, i)[cond]
+    qpr_fr = _PM.var(pm, n, :qconv_pr_fr, i)[cond]
+    ptf_to = _PM.var(pm, n, :pconv_tf_to, i)[cond]
+    qtf_to = _PM.var(pm, n, :qconv_tf_to, i)[cond]
+
+    vrf = _PM.var(pm, n, :vrf, i)[cond]
+    vif = _PM.var(pm, n, :vif, i)[cond]
+    
+    JuMP.@constraint(pm.model,   ppr_fr + ptf_to == 0 )
+    JuMP.@constraint(pm.model, qpr_fr + qtf_to +  (-bv) * filter *(vrf^2 + vif^2) == 0)
+end

--- a/src/formconv/shared.jl
+++ b/src/formconv/shared.jl
@@ -1,0 +1,68 @@
+"""
+Creates lossy converter model between AC and DC grid
+```
+pconv_ac[i] + pconv_dc[i] == a + bI + cI^2
+```
+"""
+function constraint_converter_losses(pm::_PM.AbstractPowerModel, n::Int, i::Int, a, b, c, plmax, cond)
+    pconv_ac = _PM.var(pm, n, :pconv_ac, i)[cond] #cond defined over conveter
+    pconv_dc = _PM.var(pm, n, :pconv_dc, i)[cond]
+    pconv_dcg = _PM.var(pm, n, :pconv_dcg, i)[cond]
+    iconv = _PM.var(pm, n, :iconv_ac, i)[cond]
+
+    JuMP.@NLconstraint(pm.model, pconv_ac + pconv_dc + pconv_dcg == a + b * iconv + c * iconv^2)
+end
+
+function constraint_converter_dc_current(pm::_PM.AbstractPowerModel, n::Int, i::Int, busdc::Int, vdcm, bus_cond_convs_dc_cond)
+    pconv_dc = _PM.var(pm, n, :pconv_dc, i)
+    pconv_dcg = _PM.var(pm, n, :pconv_dcg, i)
+    iconv_dc = _PM.var(pm, n, :iconv_dc, i)
+    iconv_dcg = _PM.var(pm, n, :iconv_dcg, i)
+    vdcm = _PM.var(pm, n, :vdcm, busdc)
+
+    for (bus_cond, convs) in bus_cond_convs_dc_cond
+        for (conv, conv_cond) in convs
+            if conv == i
+                JuMP.@NLconstraint(pm.model, pconv_dc[conv_cond] == iconv_dc[conv_cond] * vdcm[bus_cond])
+            end
+        end
+    end
+    for c in first(axes(iconv_dcg))
+        JuMP.@NLconstraint(pm.model, pconv_dcg[c] == iconv_dcg[c] * vdcm[3]) # neutral is always connected at bus conductor "3"
+        JuMP.@constraint(pm.model, iconv_dc[c] + iconv_dcg[c] == 0)
+    end
+    JuMP.@constraint(pm.model, sum(iconv_dc) == 0)
+end
+
+function constraint_converter_dc_ground_shunt_ohm(pm::_PM.AbstractPowerModel, n::Int, bus_convs_grounding_shunt, r_earth)
+    pconv_dcg_shunt = _PM.var(pm, n, :pconv_dcg_shunt)
+    iconv_dcg_shunt = _PM.var(pm, n, :iconv_dcg_shunt)
+
+    for i in _PM.ids(pm, n, :busdc)
+        vdcm = _PM.var(pm, n, :vdcm, i)
+        for c in bus_convs_grounding_shunt[(i, 3)]
+            r = _PM.ref(pm, n, :convdc, c)["ground_z"] + r_earth # The r_earth is kept to indicate the inclusion of earth resistance, if required in case of ground return
+            if r == 0 #solid grounding
+                JuMP.@constraint(pm.model, vdcm[3] == 0)
+            else
+                JuMP.@NLconstraint(pm.model, pconv_dcg_shunt[c] == (1 / r) * vdcm[3]^2)
+                JuMP.@constraint(pm.model, iconv_dcg_shunt[c] == (1 / r) * vdcm[3])
+            end
+        end
+    end
+end
+"""
+LCC firing angle constraints
+```
+pconv_ac == cos(phi) * Srated
+qconv_ac == sin(phi) * Srated
+```
+"""
+function constraint_conv_firing_angle(pm::_PM.AbstractPowerModel, n::Int, i::Int, S, P1, Q1, P2, Q2, cond)
+    p = _PM.var(pm, n, :pconv_ac, i)[cond]
+    q = _PM.var(pm, n, :qconv_ac, i)[cond]
+    phi = _PM.var(pm, n, :phiconv, i)[cond]
+
+    JuMP.@NLconstraint(pm.model, p == cos(phi) * S)
+    JuMP.@NLconstraint(pm.model, q == sin(phi) * S)
+end

--- a/test/prob.jl
+++ b/test/prob.jl
@@ -18,6 +18,17 @@
         end
     end
 
+    @testset "mcdcopf ACR" begin
+        @testset "case5_2grids_MC" begin
+
+            file = joinpath(_PMMCDC_dir, "test/data/matacdc_scripts/case5_2grids_MC.m")
+            result = _PMMCDC.solve_mcdcopf(file, _PM.ACRPowerModel, nlp_optimizer)
+
+            @test result["termination_status"] == _PMMCDC.LOCALLY_SOLVED
+            @test result["objective"] ≈ 869.1 rtol = 1e-3
+        end
+    end
+
     @testset "mcdcopf DCP" begin
         @testset "case5_2grids_MC" begin
 


### PR DESCRIPTION
Hi @hakanergun , @ckjat , could you please check that this PR matches your expectations and closes #19 ?

I have:
1.  created the ACR variables for the converter as in PowerModelsACDC, but supporting multiple conductors
2.  added ACR-specific constraints where needed
3.  adapted function signatures to have the correct multiple dispatch 
4. added a test that checks that the ACR result is the same as the ACP result, on the same test case
5. ~changed the project.toml so that this becomes v0.2.0, and supports any julia version including and above 1.6~

Note that I have rearranged the converter formulation files in `src/formconv`: in addition to creating the `acr.jl`, I created a `shared.jl` where I moved functions from `acp.jl` that are common to both formulations. It is a bit different from the present style, but I find it neat. Let me know if you'd rather not have it like this, tho

EDIT: after a discussion with Matteo, I improved on 3) and removed 5)